### PR TITLE
add Access-Control-Allow-Origin and Access-Control-Allow-Methods headers

### DIFF
--- a/lib/routes/gelf.js
+++ b/lib/routes/gelf.js
@@ -32,6 +32,8 @@ module.exports = function(clientGelf, config) {
 
             res.setHeader('Content-Type', 'text/html');
             res.setHeader('Content-Length', 0);
+            res.setHeader('Access-Control-Allow-Origin', '*');
+            res.setHeader('Access-Control-Allow-Methods','POST');
             res.status(201).send('message created');
 
         }


### PR DESCRIPTION
in order to perform cross domain requests
